### PR TITLE
fix(windows): resolve cycle data not found after sync

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // When running from dist/bin/cli.js, we need to go up two levels to find package.json
@@ -126,43 +126,46 @@ async function main() {
 	}
 
 	// Import and run the appropriate script
-	const scriptDir = new URL("../scripts/", import.meta.url).pathname;
+	const scriptDir = join(__dirname, "..", "scripts");
+	const importScript = (name: string) =>
+		import(pathToFileURL(join(scriptDir, name)).href);
 	try {
 		switch (command) {
 			case "init":
 				process.argv = ["node", "init.js", ...commandArgs];
-				await import(`${scriptDir}init.js`);
+				await importScript("init.js");
 				break;
 			case "sync":
-				await import(`${scriptDir}sync.js`);
+				process.argv = ["node", "sync.js", ...commandArgs];
+				await importScript("sync.js");
 				break;
 			case "work-on":
 				process.argv = ["node", "work-on.js", ...commandArgs];
-				await import(`${scriptDir}work-on.js`);
+				await importScript("work-on.js");
 				break;
 			case "estimate":
 				process.argv = ["node", "estimate.js", ...commandArgs];
-				await import(`${scriptDir}estimate.js`);
+				await importScript("estimate.js");
 				break;
 			case "done":
 				process.argv = ["node", "done-job.js", ...commandArgs];
-				await import(`${scriptDir}done-job.js`);
+				await importScript("done-job.js");
 				break;
 			case "status":
 				process.argv = ["node", "status.js", ...commandArgs];
-				await import(`${scriptDir}status.js`);
+				await importScript("status.js");
 				break;
 			case "show":
 				process.argv = ["node", "show.js", ...commandArgs];
-				await import(`${scriptDir}show.js`);
+				await importScript("show.js");
 				break;
 			case "comment":
 				process.argv = ["node", "comment.js", ...commandArgs];
-				await import(`${scriptDir}comment.js`);
+				await importScript("comment.js");
 				break;
 			case "config":
 				process.argv = ["node", "config.js", ...commandArgs];
-				await import(`${scriptDir}config.js`);
+				await importScript("config.js");
 				break;
 		}
 	} catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "team-toon-tack",
-	"version": "3.2.13",
+	"version": "3.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "team-toon-tack",
-			"version": "3.2.13",
+			"version": "3.4.0",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/prompts": "^8.1.0",

--- a/scripts/lib/init/linear-init.ts
+++ b/scripts/lib/init/linear-init.ts
@@ -222,7 +222,7 @@ export async function initLinear(
 	if (configExists && !options.force) {
 		try {
 			const existingContent = await fs.readFile(paths.configPath, "utf-8");
-			const existingConfig = decode(existingContent) as unknown as Config;
+			const existingConfig = decode(existingContent, { strict: false }) as unknown as Config;
 
 			if (existingConfig.cycle_history) {
 				config.cycle_history = existingConfig.cycle_history;
@@ -245,7 +245,7 @@ export async function initLinear(
 	if (localExists && !options.force) {
 		try {
 			const existingContent = await fs.readFile(paths.localPath, "utf-8");
-			const existingLocal = decode(existingContent) as unknown as LocalConfig;
+			const existingLocal = decode(existingContent, { strict: false }) as unknown as LocalConfig;
 
 			if (!options.interactive) {
 				if (existingLocal.current_user)

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { LinearClient } from "@linear/sdk";
+// decode uses { strict: false } because encode() produces inline arrays
+// that strict mode rejects (RangeError: Expected 0 inline array items).
 import { decode, encode } from "@toon-format/toon";
 
 // Resolve base directory - supports multiple configuration methods
@@ -219,7 +221,7 @@ export async function fileExists(filePath: string): Promise<boolean> {
 export async function loadConfig(): Promise<Config> {
 	try {
 		const fileContent = await fs.readFile(CONFIG_PATH, "utf-8");
-		return decode(fileContent) as unknown as Config;
+		return decode(fileContent, { strict: false }) as unknown as Config;
 	} catch (error) {
 		console.error(`Error loading config from ${CONFIG_PATH}:`, error);
 		console.error("Run `bun run init` to create configuration files.");
@@ -230,7 +232,7 @@ export async function loadConfig(): Promise<Config> {
 export async function loadLocalConfig(): Promise<LocalConfig> {
 	try {
 		const fileContent = await fs.readFile(LOCAL_PATH, "utf-8");
-		return decode(fileContent) as unknown as LocalConfig;
+		return decode(fileContent, { strict: false }) as unknown as LocalConfig;
 	} catch {
 		console.error(`Error: ${LOCAL_PATH} not found.`);
 		console.error("Run `bun run init` to create local configuration.");
@@ -297,9 +299,14 @@ export function getLinearClient(): LinearClient {
 export async function loadCycleData(): Promise<CycleData | null> {
 	try {
 		await fs.access(CYCLE_PATH);
-		const fileContent = await fs.readFile(CYCLE_PATH, "utf-8");
-		return decode(fileContent) as unknown as CycleData;
 	} catch {
+		return null;
+	}
+	try {
+		const fileContent = await fs.readFile(CYCLE_PATH, "utf-8");
+		return decode(fileContent, { strict: false }) as unknown as CycleData;
+	} catch (error) {
+		console.error(`Warning: Failed to decode ${CYCLE_PATH}: ${error instanceof Error ? error.message : error}`);
 		return null;
 	}
 }


### PR DESCRIPTION
## 問題描述

在 Windows 環境下，執行 `ttt sync` 成功（寫入 cycle.toon），但緊接著執行 `ttt show` 卻報錯：
```
No cycle data found. Run ttt sync first.
```
Mac 環境的同事不受影響。此問題發生在 Windows 11，`ttt` 透過 npm 全域安裝於 `C:\Program Files\nodejs\`。

## 根因調查

原本 `loadCycleData()` 將所有錯誤靜默吞掉並回傳 `null`，無法區分「檔案不存在」與「檔案存在但 decode 失敗」。拆分錯誤處理後，暴露出真正的錯誤：

```
RangeError: Expected 0 inline array items, but got 1
    at assertExpectedCount (@toon-format/toon/dist/index.mjs:373)
    at decodeInlinePrimitiveArraySync (@toon-format/toon/dist/index.mjs:589)
```

共發現三個問題：

### 1. `URL.pathname` 在 Windows 產生無效路徑
`new URL("../scripts/", import.meta.url).pathname` 在 Windows 回傳 `/C:/Program%20Files/nodejs/...` — 帶有前導 `/` 和 URL 編碼的空格，不是合法的檔案系統路徑。

### 2. `sync` 缺少 `process.argv` 設定
除了 `sync` 以外，所有 command 都在 import 前設定 `process.argv`。導致 `sync.ts` 從原始 argv 解析到 `["sync"]` 而非 `[]`。

### 3. `@toon-format/toon` strict mode decode 失敗（根本原因）
`decode()` 預設 `strict: true`，當 encode/decode 的 inline array 計數不一致時（例如 `labels: ["Frontend"]` 等單元素陣列），會拋出 `RangeError`。原本靜默的 `catch` 將此錯誤偽裝成「找不到資料」。

## 變更內容

| 檔案 | 變更 | 原因 |
|------|------|------|
| `bin/cli.ts` | `URL.pathname` 改為 `pathToFileURL(join(...)).href` | 使用 Node.js 官方 API，跨平台動態 import |
| `bin/cli.ts` | `sync` 加上 `process.argv` 設定 | 與所有其他 command 一致 |
| `scripts/utils.ts` | 所有 `decode()` 加上 `{ strict: false }` | 容忍 toon format encode/decode 不一致 |
| `scripts/utils.ts` | 拆分 `loadCycleData` 錯誤處理 | 檔案不存在 → 靜默回 null；decode 錯誤 → 印出 warning |
| `scripts/lib/init/linear-init.ts` | init merge 的 `decode()` 加上 `{ strict: false }` | 同上 strict mode 修正 |

## Mac 相容性

所有變更對 Mac 安全：
- `pathToFileURL` + `path.join` 在兩個平台都正確運作
- `{ strict: false }` 是 decode 行為變更，與平台無關
- `process.argv` 修正只是補上一致性

## 驗證結果

在 Windows 11 環境 `moldplan-frontend-2` 專案目錄下測試，全部通過：

| 指令 | 結果 |
|------|------|
| `ttt show` | ✅ 正常顯示 38 筆 issues，無 warning |
| `ttt show MP-1015` | ✅ 單一 issue 詳情 + comments 正常顯示 |
| `ttt show --label Bug` | ✅ 篩選出 16 筆 Bug issues |
| `ttt status` | ✅ 正確顯示 MP-1015 的 local/Linear 狀態 |

- [x] Windows: `ttt sync` → `ttt show` 正常顯示，無錯誤
- [x] 無 warning 訊息（decode 正常通過）
- [x] 全域安裝 npm (`C:\Program Files\nodejs\`) 驗證通過
- [ ] Mac: 待驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)